### PR TITLE
Catch errors when loading custom modules

### DIFF
--- a/pyrobud/bot.py
+++ b/pyrobud/bot.py
@@ -163,6 +163,7 @@ class Bot:
 
     def _load_modules_from_metamod(self, metamod, *, comment=None):
         for _sym in metamod.__all__:
+            if not hasattr(metamod, _sym): continue
             module_mod = getattr(metamod, _sym)
 
             if inspect.ismodule(module_mod):

--- a/pyrobud/custom_modules/__init__.py
+++ b/pyrobud/custom_modules/__init__.py
@@ -5,10 +5,11 @@ import pkgutil
 
 __all__ = list(module for _, module, _ in pkgutil.iter_modules([os.path.dirname(__file__)]))
 
-from . import *
-
-
 log = logging.getLogger("metamod_custom")
+try: from . import *
+except Exception as ex: log.error(ex)
+
+
 
 try:
     _reload_flag = _reload_flag


### PR DESCRIPTION
Allows the bot to start even when a custom module is borked