### PR TITLE
Use new pip script wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ such support are welcome.
 
 ### Using pip
 
-Run `pip3 install .` to install the bot along with all of its dependencies. After
+Run `python3 -m pip install .` to install the bot along with all of its dependencies. After
 that, you can choose to either invoke it using the `pyrobud` command, or run the bot
 in-place (which is described later in the Usage section).
 


### PR DESCRIPTION
WARNING: pip is being invoked by an old script wrapper. This will fail in a future version of pip.
Please see https://github.com/pypa/pip/issues/5599 for advice on fixing the underlying issue.
To avoid this problem you can invoke Python with '-m pip' instead of running pip directly.