### PR TITLE
Fix

### DIFF
--- a/pyrobud/util/config.py
+++ b/pyrobud/util/config.py
@@ -89,7 +89,7 @@ upgrade_methods = [
     {"version": 7, "bot": {"redact_responses": True}},
     {"version": 8, "asyncio": {"use_uvloop": True}},
     {"version": 9, "asyncio": {"debug": False}},
-    {"version": 10, "asyncio": {"use_uvloop": DeleteValue, "disable_uvloop": False}},
+    {"version": 10, "asyncio": {"disable_uvloop": False}},
 ]
 
 


### PR DESCRIPTION
This popped up after i tried to setup the bot from scratch. (in venv)

╰─➤  python3 main.py
  INFO     | launch  | Loading code...
  INFO     | launch  | Loading config
  INFO     | launch  | Initializing Sentry error reporting
  INFO     | migrate | Upgrading config to version 10
Traceback (most recent call last):
  File "main.py", line 5, in <module>
    main.main()
  File "/home/ojas/pp/pyrobud/main.py", line 27, in main
    launch.main(config_path=args.config_path)
  File "/home/ojas/pp/pyrobud/launch.py", line 66, in main
    aiorun.run(_upgrade(config, config_path), stop_on_unhandled_errors=True, loop=loop)
  File "/usr/lib/python3.7/site-packages/aiorun.py", line 294, in run
    raise pending_exception_to_raise
  File "/usr/lib/python3.7/site-packages/aiorun.py", line 206, in new_coro
    await coro
  File "/home/ojas/pp/pyrobud/launch.py", line 47, in _upgrade
    await util.config.upgrade(config, config_path)
  File "/home/ojas/pp/pyrobud/util/config.py", line 117, in upgrade
    _recursive_update(config, upgrader)
  File "/home/ojas/pp/pyrobud/util/config.py", line 59, in _recursive_update
    d[k] = _recursive_update(d.get(k, {}), v)
  File "/home/ojas/pp/pyrobud/util/config.py", line 55, in _recursive_update
    del d[k]
  File "/usr/lib/python3.7/site-packages/tomlkit/items.py", line 1022, in __delitem__
    self.remove(key)
  File "/usr/lib/python3.7/site-packages/tomlkit/items.py", line 938, in remove
    self._value.remove(key)
  File "/usr/lib/python3.7/site-packages/tomlkit/container.py", line 223, in remove
    raise NonExistentKey(key)
tomlkit.exceptions.NonExistentKey: 'Key "use_uvloop" does not exist.'
Sentry is attempting to send 0 pending error messages
Waiting up to 2 seconds
Press Ctrl-C to quit


Dunno if it is valid fix or not, but it fixed the issue for me.