### PR TITLE
Update expected response for /addsticker

### DIFF
--- a/pyrobud/modules/sticker.py
+++ b/pyrobud/modules/sticker.py
@@ -40,7 +40,7 @@ class StickerModule(module.Module):
             # We don't check this response because it's just a precautionary measure
             # Could be either failure (most likely) or success
             ("text", "/cancel", None),
-            ("text", "/addsticker", "Choose the sticker pack"),
+            ("text", "/addsticker", "Choose a sticker set"),
             ("text", pack_name, "send me the sticker"),
             ("file", sticker_data, "send me an emoji"),
             ("text", emoji, "added your sticker"),


### PR DESCRIPTION
Recently, Telegram's stickers bot response for `/addsticker` was changed from "Choose the sticker pack you're interested in." to
"Choose a sticker set." so the userbot was unable to validate the response as the substring did not match `response.raw_text`. Update the `/addsticker` expected response string to the latest match.